### PR TITLE
Sanitize file names before writing to disk and web url. Fixes bug on Windows when using bevy_mod_scripting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tealr = { version = "0.9.1", git = "https://github.com/lenscas/tealr", features 
 ] }
 v_htmlescape = "0.14.1"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+sanitize-filename = "0.5.0"

--- a/src/run_template.rs
+++ b/src/run_template.rs
@@ -313,7 +313,7 @@ pub(crate) fn run_from_walker(
                 let x = get_type_name(v).to_string();
                 (x.clone(), x)
             };
-            let link_to = link_to + ".html";
+            let link_to = sanitize_filename::sanitize(link_to) + ".html";
             SideBar {
                 link_to: link_path.join(link_to).to_string_lossy().into_owned(),
                 name,
@@ -495,11 +495,11 @@ fn run_and_write(
 ) -> Result<(), anyhow::Error> {
     let lua = unsafe { mlu::mlua::Lua::unsafe_new() };
 
-    let file_name = match &instance_setter.page {
+    let file_name = sanitize_filename::sanitize(match &instance_setter.page {
         TypeOrPage::Type(x) => &x.type_name,
         TypeOrPage::IndexPage(x) => &x.type_name,
         TypeOrPage::CustomPage(x) => &x.name,
-    }
+    })
     .to_owned()
         + ".html";
     mlu::set_global_env(instance_setter, &lua).context("Failed while setting globals")?;


### PR DESCRIPTION
Fixes cases where type name has generic types like "`LuaVec<T>`"

The bevy_mod_scripting project has a type `LuaVec<T>` which causes an error in document generation on windows. It throws an invalid file path OS Error.

Type in question: name="`crate::lua::std::LuaVec<T>`"

this PR sanitizes file names before generating their file name and HTML link. This avoids the issue, and is probably better practice anyways for web links.

For sanitization I just used a simple crate someone else made for this purpose using regex. If a different method would be preferred let me know.